### PR TITLE
Guide repository understanding step by step

### DIFF
--- a/dinov2/data/augmentations.py
+++ b/dinov2/data/augmentations.py
@@ -16,7 +16,6 @@ from skimage.color import rgb2hed, hed2rgb
 import torch
 from einops import rearrange, reduce, repeat
 import random
-import matplotlib.pyplot as plt
 logger = logging.getLogger("dinov2")
 
 import torchvision
@@ -51,6 +50,7 @@ class hed_mod(torch.nn.Module):
             img = hed2rgb(hed_image)
 
             if False:#debug
+                import matplotlib.pyplot as plt
                 fig, axes = plt.subplots(1, 2, figsize=(10, 5)) # Adjust figsize as needed
                 axes[0].imshow(img_orig)
                 axes[0].set_title("Before")

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 source .venv/bin/activate
+export MPLBACKEND=Agg
 CUDA_VISIBLE_DEVICES=0 torchrun --master_port=34001 --nproc_per_node=1 dinov2/train/train.py --config-file ./dinov2/configs/train/vits14_reg4.yaml --output-dir ./output_pretrained_on_test train.dataset_path=pathology:root=/teamspace/studios/this_studio/tcga/
 


### PR DESCRIPTION
Fix Matplotlib backend error by setting `MPLBACKEND=Agg` and moving debug-only import.

This resolves a `ValueError` caused by an invalid Matplotlib backend configuration when running the training script, particularly in headless environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa644c67-cbff-4653-975d-95d7246fa426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa644c67-cbff-4653-975d-95d7246fa426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

