### PR TITLE
Save augmentation crops for visual verification

### DIFF
--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -187,6 +187,10 @@ def do_train(cfg, model, resume=False):
         cfg.crops.local_crops_number,
         global_crops_size=cfg.crops.global_crops_size,
         local_crops_size=cfg.crops.local_crops_size,
+        # Debug/visualization controls via env vars to avoid config churn
+        save_crops=bool(int(os.getenv("SAVE_CROPS", "0"))),
+        save_dir=os.getenv("SAVE_CROPS_DIR", os.path.join(cfg.train.output_dir, "crops_debug")),
+        save_first_n=int(os.getenv("SAVE_CROPS_FIRST_N", "20")),
     )
 
     collate_fn = partial(


### PR DESCRIPTION
Add optional crop saving to `DataAugmentationDINO` for visual verification of global and local crops.

---
<a href="https://cursor.com/background-agent?bcId=bc-92fedb95-6ea9-404a-bd34-c53612383361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92fedb95-6ea9-404a-bd34-c53612383361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

